### PR TITLE
Add support for ItemMeta and a command to set items from current inventory.

### DIFF
--- a/src/main/java/me/chaseoes/firstjoinplus/FirstJoinListener.java
+++ b/src/main/java/me/chaseoes/firstjoinplus/FirstJoinListener.java
@@ -122,11 +122,6 @@ public class FirstJoinListener implements Listener {
             }, invincible * 20L);
         }
 
-        // Written books!
-        if (plugin.getConfig().getBoolean("on-first-join.give-written-books.enabled")) {
-            Utilities.getUtilities().giveWrittenBooks(player);
-        }
-        
         // Apply potion effects!
         if (plugin.getConfig().getBoolean("on-first-join.apply-potion-effects.enabled")) {
             List<PotionEffect> effects = new ArrayList<PotionEffect>();

--- a/src/main/java/me/chaseoes/firstjoinplus/FirstJoinPlus.java
+++ b/src/main/java/me/chaseoes/firstjoinplus/FirstJoinPlus.java
@@ -142,12 +142,18 @@ public class FirstJoinPlus extends JavaPlugin {
             }
         }
 
+        if (strings[0].equalsIgnoreCase("setitems")) {
+            if (cs.hasPermission("firstjoinplus.setitems")) {
+                Utilities.getUtilities().setItemsFromInventory(player);
+                cs.sendMessage(prefix + ChatColor.GREEN + "Successfully set the first join items to your current inventory.");
+            } else {
+                cs.sendMessage(noPermission);
+            }
+        }
+
         if (strings[0].equalsIgnoreCase("items")) {
             if (cs.hasPermission("firstjoinplus.items")) {
                 Utilities.getUtilities().giveFirstJoinItems(player);
-                if (getConfig().getBoolean("on-first-join.give-written-books.enabled")) {
-                    Utilities.getUtilities().giveWrittenBooks(player);
-                }
                 cs.sendMessage(prefix + ChatColor.GREEN + "Successfully gave all defined items.");
             } else {
                 cs.sendMessage(noPermission);

--- a/src/main/java/me/chaseoes/firstjoinplus/utilities/Utilities.java
+++ b/src/main/java/me/chaseoes/firstjoinplus/utilities/Utilities.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.logging.Level;
 
 import me.chaseoes.firstjoinplus.FirstJoinPlus;
@@ -61,25 +63,28 @@ public class Utilities {
         plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
             @Override
             public void run() {
-                for (String itemStr : plugin.getConfig().getStringList("on-first-join.give-items.items")) {
-                    ItemStack i;
-                    String[] itemValues = itemStr.split("\\:");
-
-                    if (isNumber(itemValues[0])) {
-                        i = new ItemStack(Material.getMaterial(Integer.parseInt(itemValues[0])));
+                for (Object item : plugin.getConfig().getList("on-first-join.give-items.items")) {
+                    if (item instanceof ItemStack) {
+                        player.getInventory().addItem((ItemStack) item);
                     } else {
-                        i = new ItemStack(Material.getMaterial(itemValues[0].toUpperCase()));
-                    }
+                        ItemStack i;
+                        String[] itemValues = ((String) item).split("\\:");
 
-                    if (itemValues.length > 1) {
-                        i.setAmount(Integer.parseInt(itemValues[1]));
-                    }
+                        if (isNumber(itemValues[0])) {
+                            i = new ItemStack(Material.getMaterial(Integer.parseInt(itemValues[0])));
+                        } else {
+                            i = new ItemStack(Material.getMaterial(itemValues[0].toUpperCase()));
+                        }
 
-                    if (itemValues.length > 2) {
-                        i = new ItemStack(i.getType(), i.getAmount(), (short) Integer.parseInt(itemValues[2]));
-                    }
+                        if (itemValues.length > 1) {
+                            i.setAmount(Integer.parseInt(itemValues[1]));
+                        }
 
-                    player.getInventory().addItem(i);
+                        if (itemValues.length > 2) {
+                            i = new ItemStack(i.getType(), i.getAmount(), (short) Integer.parseInt(itemValues[2]));
+                        }
+                        player.getInventory().addItem(i);
+                    }
                 }
             }
         }, plugin.getConfig().getLong("on-first-join.give-items.delay"));
@@ -187,5 +192,17 @@ public class Utilities {
         }
         return "N/A";
     }
+
+    public void setItemsFromInventory(Player player) {
+        List<ItemStack> items = new LinkedList<ItemStack>();
+        for (ItemStack stack: player.getInventory().getContents()) {
+            if (stack != null) {
+                items.add(stack);
+            }
+        }
+        plugin.getConfig().set("on-first-join.give-items.items", items);
+        plugin.saveConfig();
+    }
+
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,9 +17,16 @@ on-first-join:
     enabled: true
     delay: 0
     items:
-    - WOOD_PICKAXE
-    - BREAD:5
-    - WOOL:10:6
+     - ==: org.bukkit.inventory.ItemStack
+       type: WOOD_PICKAXE
+     - ==: org.bukkit.inventory.ItemStack
+       type: BREAD
+       amount: 5
+     - ==: org.bukkit.inventory.ItemStack
+       type: WOOL
+       damage: 6
+       amount: 10
+
   give-written-books:
     enabled: false
     delay: 0

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,6 +20,8 @@ permissions:
     description: Permission to use the /firstjoinplus setspawn command.
   firstjoinplus.items:
     description: Permission to use the /firstjoinplus items command.
+  firstjoinplus.setitems:
+    description: Permission to use the /firstjoinplus setitems command.
   firstjoinplus.spawn:
     description: Permission to use the /firstjoinplus spawn command.
   firstjoinplus.notify:


### PR DESCRIPTION
First let me say I know this might be problematic to pull as-is since it makes several changes, feel free to reject and just take whatever you might be interested in.  

Firstly, it adds support for directly serializing and deserializing itemstacks from the give-items.items list, so that any items with any meta can be supported, it does so in a backwards compatible way so that the old colon-separated-string format will still work.

Secondly it drops all the custom written book code, as it becomes redundant when full item meta is supported.  (though the interface may not be as nice as a text-editor, so this is controvercial)

Thirdly it adds a setitems command that populates the give-items.items list with the contents of the CommandSender's inventory.
