### PR TITLE
Fixed error when server admin uses eanother world directory.

### DIFF
--- a/src/main/java/me/chaseoes/firstjoinplus/utilities/Utilities.java
+++ b/src/main/java/me/chaseoes/firstjoinplus/utilities/Utilities.java
@@ -45,7 +45,7 @@ public class Utilities {
     }
 
     public int getUniquePlayerCount() {
-        return new File(plugin.getServer().getWorlds().get(0).getName() + "/players/").list().length;
+        return new File(plugin.getServer().getWorldContainer(),plugin.getServer().getWorlds().get(0).getName() + "/players/").list().length;
     }
 
     public Location getFirstJoinLocation() {


### PR DESCRIPTION
When another world directory is used, the plugin throws a null pointer. This patch fixes that assumption.
